### PR TITLE
Button dark mode configuration

### DIFF
--- a/app/controllers/rails_base/application_controller.rb
+++ b/app/controllers/rails_base/application_controller.rb
@@ -5,7 +5,7 @@ module RailsBase
     before_action :is_timeout_error?
     before_action :admin_reset_impersonation_session!
     before_action :populate_admin_actions, if: -> { RailsBase.config.admin.enable_actions? }
-    before_action :sticky_footer_mode?
+    before_action :footer_mode_case
 
     after_action :capture_admin_action, if: -> { RailsBase.config.admin.enable_actions? }
 

--- a/app/helpers/rails_base/appearance_helper.rb
+++ b/app/helpers/rails_base/appearance_helper.rb
@@ -19,16 +19,19 @@ module RailsBase::AppearanceHelper
     VIEWPORT_EXTRA_LARGE => nil,
   }
 
-  def sticky_footer_mode?
-    return true if @_sticky_mode
+  def footer_mode_case
+    return :sticky if @_sticky_mode
+
+    return :bottom if RailsBase.appearance.footer.content_bottom_or_sticky
 
     sticky_pages = RailsBase.appearance.footer.sticky_pages
-    return false if sticky_pages.empty?
+    return if sticky_pages.empty?
 
     full_controller_path = "#{controller_path.camelize}Controller"
     return unless pages = sticky_pages[full_controller_path]
 
-    pages.include?(action_name.to_sym)
+    return :sticky if pages.include?(action_name.to_sym)
+    nil
   end
 
   def force_sticky_mode!

--- a/app/views/layouts/rails_base/application.html.erb
+++ b/app/views/layouts/rails_base/application.html.erb
@@ -69,7 +69,7 @@
 
     <% rails_base_alert = "alertid-#{(10**10*rand).to_i}" %>
     <% rails_base_success = "successid-#{(10**10*rand).to_i}"%>
-    <div id='_body_base_container' class="container-fluid">
+    <div id='_body_base_container' class="container-fluid" style="overflow-x: hidden !important;">
       <% if current_user %>
         <%= render partial: 'rails_base/shared/logged_in_header'%>
       <% else %>
@@ -107,13 +107,8 @@
         <%= yield %>
       </div>
 
-          <% if RailsBase.appearance.footer.enable? %>
-      <% if sticky_footer_mode? %>
-      <div style="margin-top: 70px"></div>
-      <footer class="text-center fixed-bottom">
-      <% else %>
-      <footer class="text-center" style="left: 0,right:0">
-      <% end %>
+      <% if RailsBase.appearance.footer.enable? %>
+      <footer id="base-footer" class="text-center">
         <div class="text-center p-2 <%= appearance_text_class %>">
           <%= raw RailsBase.appearance.footer.html %>
         </div>
@@ -138,12 +133,22 @@
       function _rails_base_hide_displays(){
         $('#<%= rails_base_alert %>').hide()
         $('#<%= rails_base_success %>').hide()
-      }
+      };
 
       <%
         # dont load these when error page happens. The full stack of librarires are not
         # rendered and jquery/bootstrap are missing
       %>
+      <% case footer_mode_case %>
+      <% when :sticky %>
+      $('#base-footer').addClass('fixed-bottom')
+      <% when :bottom %>
+      if($('#_body_base_container').height() <= window.innerHeight){
+        $('#base-footer').addClass('fixed-bottom')
+      }
+      <% else %>
+      <% end %>
+
       <% unless defined?(@error_page) %>
       $(document).ready(function(){
         $('[data-toggle="tooltip"]').tooltip();

--- a/app/views/rails_base/admin/index.html.erb
+++ b/app/views/rails_base/admin/index.html.erb
@@ -5,7 +5,7 @@
     <%= select_tag 'admin_filter_user_by', options_for_select(filters), include_blank: 'Filter Users', class: 'form-control', onchange: 'filter_admins()' %>
   </div>
 </div>
-<div class='table-responsive-xl' >
+<div class='table-responsive' style="overflow-x:auto; width: inherit !important;">
   <table class="tableFixHead table table-striped table-bordered">
     <thead class="thead-dark text-center">
       <% RailsBase.config.admin.admin_page_tiles.each do |tile| %>

--- a/app/views/rails_base/devise/passwords/new.html.erb
+++ b/app/views/rails_base/devise/passwords/new.html.erb
@@ -16,10 +16,10 @@
     <div class="col-md-10 offset-md-1 text-center">
       <div class="row">
         <div class="col-md-9">
-          <%= f.submit "Send me reset password instructions", class: "btn btn-success btn-block" %>
+          <%= f.submit "Send me reset password instructions", class: "btn btn_success btn-block" %>
         </div>
         <div class="col-md-3">
-          <a class="btn btn-primary btn-block" href="<%= RailsBase.url_routes.new_user_session_path %>" role="button">Sign in</a>
+          <a class="btn btn_primary btn-block" href="<%= RailsBase.url_routes.new_user_session_path %>" role="button">Sign in</a>
         </div>
       </div>
     </div>

--- a/app/views/rails_base/devise/registrations/new.html.erb
+++ b/app/views/rails_base/devise/registrations/new.html.erb
@@ -69,10 +69,10 @@
     <div class="col-md-10 offset-md-1 text-center">
       <div class="row">
         <div class="col-md-9">
-          <%= f.submit "Sign Up for #{Rails.application.class.parent_name}", class: "btn btn-success btn-block #{submit_klass}" %>
+          <%= f.submit "Sign Up for #{Rails.application.class.parent_name}", class: "btn btn_success btn-block #{submit_klass}" %>
         </div>
         <div class="col-md-3">
-          <a class="btn btn-primary btn-block" href="<%=RailsBase.url_routes.new_user_session_path%>" role="button">Have an Account? Sign In</a>
+          <a class="btn btn_primary btn-block" href="<%=RailsBase.url_routes.new_user_session_path%>" role="button">Have an Account? Sign In</a>
         </div>
       </div>
     </div>

--- a/app/views/rails_base/mfa_auth/mfa_code.html.erb
+++ b/app/views/rails_base/mfa_auth/mfa_code.html.erb
@@ -4,7 +4,7 @@
     <%= render partial: 'rails_base/shared/mfa_input_layout', locals: { url: RailsBase.url_routes.mfa_code_verify_path, size: 30, masked_phone: @masked_phone }%>
     <br>
     <div class="text-center">
-      <%= button_to 'Resend MFA', RailsBase.url_routes.resend_mfa_path, method: :post, class: 'btn btn-warning', style: 'width: 25%;'  %>
+      <%= button_to 'Resend MFA', RailsBase.url_routes.resend_mfa_path, method: :post, class: 'btn btn_warning', style: 'width: 25%;'  %>
     </div>
   </div>
 </div>

--- a/app/views/rails_base/secondary_authentication/static.html.erb
+++ b/app/views/rails_base/secondary_authentication/static.html.erb
@@ -1,5 +1,5 @@
 <div class="row" >
   <div class="col-md-6 offset-md-3"style="position: absolute; top:25%">
-  	<%= button_to 'Resend Verification Email', RailsBase.url_routes.resend_email_verification_path, method: :post, class: 'align-middle btn btn-warning btn-lg btn-block', style: 'font-size: 30px' %>
+  	<%= button_to 'Resend Verification Email', RailsBase.url_routes.resend_email_verification_path, method: :post, class: 'align-middle btn btn_warning btn-lg btn-block', style: 'font-size: 30px' %>
   </div>
 </div>

--- a/app/views/rails_base/shared/_admin_actions_modal.html.erb
+++ b/app/views/rails_base/shared/_admin_actions_modal.html.erb
@@ -28,7 +28,7 @@
         <% end%>
       </div>
       <div class="modal-footer">
-        <button type="button" id='ackAdminActionAccept' class="btn btn-block btn-warning">Acknowledge</button>
+        <button type="button" id='ackAdminActionAccept' class="btn btn-block btn_warning">Acknowledge</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/shared/_admin_config_class.html.erb
+++ b/app/views/rails_base/shared/_admin_config_class.html.erb
@@ -15,23 +15,26 @@
           <% when :proc %>
             <td>
               <% users = users_for_proc(instance.public_send(name)) %>
-              <a tabindex="0" class="btn btn-secondary" role="button" data-toggle="popover" data-trigger="focus" title="Users with ability" data-html=true data-content="<%=users.join('</br>')%>">View Users</a>
+              <a tabindex="0" class="btn btn_secondary" role="button" data-toggle="popover" data-trigger="focus" title="Users with ability" data-html=true data-content="<%=users.join('</br>')%>">View Users</a>
             </td>
           <% when :duration %>
             <td> <%= instance.public_send(name).inspect %> </td>
           <% when :array %>
             <td>
               <% array = array_for_proc(object[:decipher], instance.public_send(name)) %>
-              <a tabindex="0" class="btn btn-secondary" role="button" data-toggle="popover" data-trigger="focus" title="Configured List" data-html=true data-content="<%=array.join('</br>')%>">View List</a>
+              <a tabindex="0" class="btn btn_secondary" role="button" data-toggle="popover" data-trigger="focus" title="Configured List" data-html=true data-content="<%=array.join('</br>')%>">View List</a>
             </td>
           <% else %>
             <td>
               <% if object[:secret] %>
                 < Secret Value >
+              <% elsif object[:popover] %>
+                <% array = object[:decipher].call(instance.public_send(name)) %>
+                <a tabindex="0" class="btn btn_secondary" role="button" data-toggle="popover" data-trigger="focus" title="Configured List" data-html=true data-content="<%=array.join('</br>')%>">View List</a>
               <% elsif object[:decipher] %>
                 <%= object[:decipher].call(instance.public_send(name)).to_s %>
               <% else %>
-                <%= instance.public_send(name) %>
+                <%= raw instance.public_send(name) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/rails_base/shared/_admin_history.html.erb
+++ b/app/views/rails_base/shared/_admin_history.html.erb
@@ -34,7 +34,7 @@
 <nav aria-label="Page navigation">
   <ul class="pagination justify-content-center">
     <li class="page-item <%= 'disabled' unless paginate_admin_can_prev?(page_number: @starting_page, count_on_page: @count_on_page) %>">
-      <p class="page-link" onClick="submit_paginate(<%= @starting_page - 1%>, <%= @starting_page %>, <%= @count_on_page %>)" style='cursor: pointer;'>Previous</p>
+      <p class="page-link" onClick="submit_paginate(<%= @starting_page - 1%>, <%= @starting_page %>, <%= @count_on_page %>)" style='cursor: pointer;'>Prev</p>
     </li>
     <% paginate_admin_history_range(start: @starting_page).each do |page| %>
     <% next unless page > 0 %>

--- a/app/views/rails_base/shared/_admin_modify_email.html.erb
+++ b/app/views/rails_base/shared/_admin_modify_email.html.erb
@@ -22,11 +22,11 @@
         </div>
       </div>
       <div class="col-auto my-1">
-        <button id='<%= modal_prepend %>' class="btn btn-success">Submit</button>
+        <button id='<%= modal_prepend %>' class="btn btn_success">Submit</button>
       </div>
     </div>
     <div class="modal-footer">
-      <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+      <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
     </div>
   </div>
 </div>

--- a/app/views/rails_base/shared/_admin_modify_name.html.erb
+++ b/app/views/rails_base/shared/_admin_modify_name.html.erb
@@ -37,11 +37,11 @@
           </div>
         </div>
         <div class="col-auto my-1">
-          <button id='<%= modal_prepend %>' class="btn btn-success">Submit</button>
+          <button id='<%= modal_prepend %>' class="btn btn_success">Submit</button>
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/shared/_admin_modify_phone.html.erb
+++ b/app/views/rails_base/shared/_admin_modify_phone.html.erb
@@ -28,11 +28,11 @@
         </div>
       </div>
       <div class="col-auto my-1">
-        <button id='modify_phone_submit' class="btn btn-success">Submit</button>
+        <button id='modify_phone_submit' class="btn btn_success">Submit</button>
       </div>
     </div>
     <div class="modal-footer">
-      <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+      <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
     </div>
   </div>
 </div>

--- a/app/views/rails_base/shared/_admin_risky_change.html.erb
+++ b/app/views/rails_base/shared/_admin_risky_change.html.erb
@@ -40,7 +40,7 @@
         <%= render partial: 'rails_base/shared/admin_risky_mfa', locals: { modal_id: risky_modal_id, user: user, parent: "#{parent}_#{type}", text: text_id, next_modal: partial_modal, modal_mapping: modal_mapping, modify_id: text_id } %>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/shared/_admin_risky_mfa.html.erb
+++ b/app/views/rails_base/shared/_admin_risky_mfa.html.erb
@@ -15,8 +15,8 @@
   </div>
 </div>
 <div class="text-center">
-  <button id='<%= mfa_id_submit %>' class="btn btn-success" type="submit" style='width:50%;'>Submit</button>
-  <button class="btn btn-info btn-block" id='<%= mfa_id_submit %>_spinner' type="button" disabled style="display: none">
+  <button id='<%= mfa_id_submit %>' class="btn btn_success" type="submit" style='width:50%;'>Submit</button>
+  <button class="btn btn_info btn-block" id='<%= mfa_id_submit %>_spinner' type="button" disabled style="display: none">
     <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true">
     </span>
     Hang tight

--- a/app/views/rails_base/shared/_admin_selector_dropdown.html.erb
+++ b/app/views/rails_base/shared/_admin_selector_dropdown.html.erb
@@ -6,7 +6,7 @@
 
 <% if !disable_action %>
 <%= select_tag input_id, options_for_select(options, selector), class: 'form-control' %>
-<button class="btn btn-info btn-block" id='<%= span_id %>' type="button" disabled style="display: none">
+<button class="btn btn_info btn-block" id='<%= span_id %>' type="button" disabled style="display: none">
   <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true">
   </span>
   Hang tight

--- a/app/views/rails_base/shared/_admin_toggle_button.html.erb
+++ b/app/views/rails_base/shared/_admin_toggle_button.html.erb
@@ -19,7 +19,7 @@
   <div id='<%= div_span %>' class='text-center'>
     <input id='<%= input_id %>' class='admin-concurrent-block' type="checkbox" <%= 'checked' if checked %> data-toggle="toggle" data-on='<%= data_on %>' data-off='<%= data_off %>' data-onstyle='success' data-offstyle='warning'>
   </div>
-  <button class="btn btn-info btn-block" id='<%= span_id %>' type="button" disabled style="display: none">
+  <button class="btn btn_info btn-block" id='<%= span_id %>' type="button" disabled style="display: none">
     <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true">
     </span>
     Hang tight

--- a/app/views/rails_base/shared/_admin_warning_alert.html.erb
+++ b/app/views/rails_base/shared/_admin_warning_alert.html.erb
@@ -4,4 +4,4 @@
 <p class="mb-0 text-center">
   You are using admin privaleges (id: <%= session[RailsBase::Authentication::Constants::ADMIN_REMEMBER_USERID_KEY] %>) to impersonate a user. You are curently logged in as [<%= current_user.full_name%>] (user id:<%= current_user.id%>)
 </p>
-<%= button_to 'Return to my account', RailsBase.url_routes.admin_stop_impersonation_path, method: :post, class: 'btn btn-warning btn-block'  %>
+<%= button_to 'Return to my account', RailsBase.url_routes.admin_stop_impersonation_path, method: :post, class: 'btn btn_warning btn-block'  %>

--- a/app/views/rails_base/shared/_appearance_mode_selector.html.erb
+++ b/app/views/rails_base/shared/_appearance_mode_selector.html.erb
@@ -1,7 +1,7 @@
 <% if RailsBase.appearance.enabled %>
   <% if display %>
     <!-- Button trigger modal -->
-    <button type="button" class="btn btn-info <%= btn%> close-me" data-toggle="modal" data-target="#appearance_mode_selector">
+    <button type="button" class="btn btn_info <%= btn%> close-me" data-toggle="modal" data-target="#appearance_mode_selector">
       Dark/Lite Mode
     </button>
 
@@ -20,7 +20,7 @@
             <%= select_tag 'appearance_mode_selector_id', options_for_select(appearance_mode_drop_down[:types_a]), class: 'form-control', include_blank: 'Select Appearance Mode' %>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-block btn-secondary" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-block btn_secondary" data-dismiss="modal">Close</button>
           </div>
         </div>
       </div>
@@ -111,6 +111,15 @@
         '<%= dark %>': '<%= RailsBase.appearance.text.dark_mode %>',
         '<%= light %>': '<%= RailsBase.appearance.text.light_mode %>'
       },
+      // buttons
+      <% RailsBase.appearance.class::BUTTONS.each do |klass| %>
+      {
+        'descriptor': '.<%= klass %>',
+        '<%= dark %>': '<%= RailsBase.appearance.dig(klass, :dark_mode) %>',
+        '<%= light %>': '<%= RailsBase.appearance.dig(klass, :light_mode) %>'
+      },
+      <% end %>
+
     ]
 
     function toggle_dark_mode(set_key){
@@ -119,11 +128,12 @@
       remove_keys.splice( $.inArray(set_key, remove_keys),1 );
       for (i = 0; i < dark_mode_changes.length; ++i) {
         var descriptor = dark_mode_changes[i]['descriptor']
+        elements = $(`${descriptor}`)
         for (s = 0; s < remove_keys.length; ++s) {
-          $(`${descriptor}`).removeClass(dark_mode_changes[i][remove_keys[s]])
+          elements.removeClass(dark_mode_changes[i][remove_keys[s]])
         }
         var insert = dark_mode_changes[i][set_key]
-        $(`${descriptor}`).addClass(insert)
+        elements.addClass(insert)
       }
     }
 

--- a/app/views/rails_base/shared/_enable_mfa_auth_modal.html.erb
+++ b/app/views/rails_base/shared/_enable_mfa_auth_modal.html.erb
@@ -18,8 +18,8 @@
 		      				</span>
 		      			</div>
 		   		   		<%= phone_field_tag(:user_phone_number, nil, style: "font-size:25px;", class: 'phone_us', maxlength: 14, size: 15)%>
-		   		   		<button type="button" class="btn btn-success submit-phone-number" id="submit-phone-number" disabled>Submit Phone</button>
-		   		   		<button id="loading-phone-number" class="btn btn-success" type="button" disabled style="display: none;">
+		   		   		<button type="button" class="btn btn_success submit-phone-number" id="submit-phone-number" disabled>Submit Phone</button>
+		   		   		<button id="loading-phone-number" class="btn btn_success" type="button" disabled style="display: none;">
 		   		   		  <span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>
   								Loading...
 		   		   		</button>
@@ -33,7 +33,7 @@
       	</div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/shared/_logged_in_header.html.erb
+++ b/app/views/rails_base/shared/_logged_in_header.html.erb
@@ -19,11 +19,11 @@
       <% end %>
     </ul>
     <% if defined?(@error_page)%>
-      <button onclick="goBack()" class="btn btn-warning">
+      <button onclick="goBack()" class="btn btn_warning">
         &#8592; Return to Previous page
       </button>
     <%else%>
-    <button type="button" class="btn btn-light" data-toggle="modal" data-target="#settings_modal">
+    <button type="button" class="btn btn_secondary" data-toggle="modal" data-target="#settings_modal">
       My Settings
     </button>
     <%end%>
@@ -45,11 +45,11 @@
           <div class='col'>
             <% if RailsBase.config.mfa.enable? %>
               <% if current_user.mfa_enabled %>
-                <button type="button" class="btn-block btn-info close-me" data-toggle="modal" data-target="#modifyMfamodal">
+                <button type="button" class="btn btn-block btn_info close-me" data-toggle="modal" data-target="#modifyMfamodal">
                     Modify 2fa Auth
                 </button>
               <% else %>
-                <button type="button" class="btn btn-block btn-info close-me" data-toggle="modal" data-target="#enableMfamodal">
+                <button type="button" class="btn btn-block btn_info close-me" data-toggle="modal" data-target="#enableMfamodal">
                   Enable 2fa Auth
                 </button>
               <% end %>
@@ -59,7 +59,7 @@
         </br>
         <div class='row'>
           <div class='col'>
-            <a class="btn btn-info btn-block" href="<%=RailsBase.url_routes.user_settings_path%>" role="button">Modify User</a>
+            <a class="btn btn_info btn-block" href="<%=RailsBase.url_routes.user_settings_path%>" role="button">Modify User</a>
           </div>
         </div>
         </br>
@@ -72,7 +72,7 @@
           <div class="dropdown-divider"></div>
         <div class='row'>
           <div class='col'>
-          <%= button_to 'Logout', RailsBase.url_routes.signout_path, method: :delete, class: 'btn btn-danger btn-block'  %>
+          <%= button_to 'Logout', RailsBase.url_routes.signout_path, method: :delete, class: 'btn btn_danger btn-block'  %>
           </div>
         </div>
       </div>

--- a/app/views/rails_base/shared/_logged_out_header.html.erb
+++ b/app/views/rails_base/shared/_logged_out_header.html.erb
@@ -7,7 +7,7 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <div class="mr-auto">
     </div>
-    <a class="btn btn-primary my-2 my-sm-0" href="<%=Rails.application.routes.url_helpers.new_user_registration_path%>" role="button">Sign Up</a>
+    <a class="btn btn_primary my-2 my-sm-0" href="<%=Rails.application.routes.url_helpers.new_user_registration_path%>" role="button">Sign Up</a>
   </div>
 </nav>
 

--- a/app/views/rails_base/shared/_mfa_input_layout_default.html.erb
+++ b/app/views/rails_base/shared/_mfa_input_layout_default.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="text-center">
     <% unless defined?(disable) %>
-    <%= f.submit "submit", class: "submit-mfa btn btn-success", style: "width: 50%;", disabled: true %>
+    <%= f.submit "submit", class: "submit-mfa btn btn_success", style: "width: 50%;", disabled: true %>
     <%end%>
   </div>
 <% end %>

--- a/app/views/rails_base/shared/_mfa_input_layout_fallback.html.erb
+++ b/app/views/rails_base/shared/_mfa_input_layout_fallback.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   </div>
   <div class="text-center">
-    <%= f.submit "submit", class: "submit-mfa btn btn-success", style: "width: 50%;"%>
+    <%= f.submit "submit", class: "submit-mfa btn btn_success", style: "width: 50%;"%>
   </div>
 <% end %>
 

--- a/app/views/rails_base/shared/_modify_mfa_auth_modal.html.erb
+++ b/app/views/rails_base/shared/_modify_mfa_auth_modal.html.erb
@@ -10,10 +10,10 @@
         </button>
       </div>
       <div class="modal-body">
-        <%= button_to "Disable 2fa", RailsBase.url_routes.remove_phone_registration_mfa_path, data: { confirm: confirm }, method: :delete, class: "btn btn-danger btn-block" %>
+        <%= button_to "Disable 2fa", RailsBase.url_routes.remove_phone_registration_mfa_path, data: { confirm: confirm }, method: :delete, class: "btn btn_danger btn-block" %>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/shared/_reset_password_form.html.erb
+++ b/app/views/rails_base/shared/_reset_password_form.html.erb
@@ -24,10 +24,10 @@
       <div class="col-md-10 offset-md-1 text-center">
         <div class="row">
           <div class="col-md-9">
-            <%= f.submit "Reset Password", class: "reset-password-submit btn btn-success btn-block", disabled: true %>
+            <%= f.submit "Reset Password", class: "reset-password-submit btn btn_success btn-block", disabled: true %>
           </div>
           <div class="col-md-3">
-            <a class="btn btn-primary btn-block" href="<%=RailsBase.url_routes.new_user_session_path%>" role="button">Sign in</a>
+            <a class="btn btn_primary btn-block" href="<%=RailsBase.url_routes.new_user_session_path%>" role="button">Sign in</a>
           </div>
         </div>
       </div>
@@ -35,7 +35,7 @@
   <% else %>
   <div class="actions row">
     <div class="col-md-10 offset-md-1 text-center">
-      <%= f.submit "Reset Password", class: "btn btn-success btn-block" %>
+      <%= f.submit "Reset Password", class: "btn btn_success btn-block" %>
     </div>
   </div>
   <% end %>

--- a/app/views/rails_base/shared/_session_create_form.html.erb
+++ b/app/views/rails_base/shared/_session_create_form.html.erb
@@ -16,13 +16,13 @@
 
       <div class="actions row">
         <div class="col-md-6 offset-md-1">
-          <%= f.submit "Log in", class: "btn btn-success btn-block" %>
+          <%= f.submit "Log in", class: "btn btn_success btn-block" %>
         </div>
         <div class="col-md-2">
-          <a class="btn btn-primary btn-block" href="<%=Rails.application.routes.url_helpers.new_user_registration_path%>" role="button">Sign up</a>
+          <a class="btn btn_primary btn-block" href="<%=Rails.application.routes.url_helpers.new_user_registration_path%>" role="button">Sign up</a>
             </div>
             <div class="col-md-2">
-              <a class="btn btn-primary btn-block" href="<%=Rails.application.routes.url_helpers.new_user_password_path%>" role="button">Forgot Password?</a>
+              <a class="btn btn_primary btn-block" href="<%=Rails.application.routes.url_helpers.new_user_password_path%>" role="button">Forgot Password?</a>
             </div>
           </div>
         </div>

--- a/app/views/rails_base/shared/_session_timeout_modal.html.erb
+++ b/app/views/rails_base/shared/_session_timeout_modal.html.erb
@@ -17,7 +17,7 @@
         <strong id='modify_counter' style="font-size: 300%"><%= default_time %></strong>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary btn-block" data-dismiss="modal">Save Session</button>
+        <button type="button" class="btn btn_secondary btn-block" data-dismiss="modal">Save Session</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/user_settings/_destroy_user.html.erb
+++ b/app/views/rails_base/user_settings/_destroy_user.html.erb
@@ -22,10 +22,10 @@
           </div>
           <div class="actions row">
             <div class="col-md-10 offset-md-1 text-center">
-              <button type="button" class="btn btn-success" id="confirm-destroy-current-password">
+              <button type="button" class="btn btn_success" id="confirm-destroy-current-password">
               Confirm Password
               </button>
-              <button class="btn btn-success" id='confirm-destroy-current-password-wait' type="button" disabled style="display: none">
+              <button class="btn btn_success" id='confirm-destroy-current-password-wait' type="button" disabled style="display: none">
                 <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true">
                 </span>
                 Please wait...
@@ -36,9 +36,9 @@
       </div>
       <div class="modal-footer">
         <fieldset class="w-100">
-          <button type="button" class="btn btn-secondary float-left" data-dismiss="modal" >Close</button>
+          <button type="button" class="btn btn_secondary float-left" data-dismiss="modal" >Close</button>
 
-          <%= button_to "Destroy User", RailsBase.url_routes.destroy_user_path, class: "destroy_user_btn btn btn-danger disabled float-right disabled", params: { data: nil }%>
+          <%= button_to "Destroy User", RailsBase.url_routes.destroy_user_path, class: "destroy_user_btn btn btn_danger disabled float-right disabled", params: { data: nil }%>
         </fieldset>
       </div>
     </div>

--- a/app/views/rails_base/user_settings/_modify_name.html.erb
+++ b/app/views/rails_base/user_settings/_modify_name.html.erb
@@ -35,12 +35,12 @@
           </div>
 
           <div class="actions">
-            <%= f.submit "Confirm Name Change", class: "submit-name-change btn btn-success", style: "width: 50%;" %>
+            <%= f.submit "Confirm Name Change", class: "submit-name-change btn btn_success", style: "width: 50%;" %>
           </div>
         <% end %>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/user_settings/_modify_password.html.erb
+++ b/app/views/rails_base/user_settings/_modify_password.html.erb
@@ -21,10 +21,10 @@
       		</div>
       		<div class="actions row">
       		  <div class="col-md-10 offset-md-1 text-center">
-      		    <button type="button" class="btn btn-success" id="confirm-current-password">
+      		    <button type="button" class="btn btn_success" id="confirm-current-password">
       		      Confirm Password
       		    </button>
-      		    <button class="btn btn-success" id='confirm-current-password-wait' type="button" disabled style="display: none">
+      		    <button class="btn btn_success" id='confirm-current-password-wait' type="button" disabled style="display: none">
       		      <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true">
       		      </span>
       		      Please wait...
@@ -35,7 +35,7 @@
       	</div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="mr-auto btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="mr-auto btn btn_secondary" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/views/rails_base/user_settings/index.html.erb
+++ b/app/views/rails_base/user_settings/index.html.erb
@@ -11,7 +11,7 @@
               <%= current_user.full_name %>
             </td>
             <td style="width: 20%">
-              <button class="btn btn-primary btn-block show-create-modal" data-toggle="modal" data-target="#modifyNameModal" type="button">Modify</button>
+              <button class="btn btn_primary btn-block show-create-modal" data-toggle="modal" data-target="#modifyNameModal" type="button">Modify</button>
             </td>
           </tr>
           <tr>
@@ -22,7 +22,7 @@
               <%= current_user.mfa_enabled %>
             </td>
             <td style="width: 20%">
-              <button class="btn btn-primary btn-block show-create-modal" type="button">Modify</button>
+              <button class="btn btn_primary btn-block show-create-modal" type="button">Modify</button>
             </td>
           </tr>
           <tr>
@@ -33,14 +33,14 @@
               <%= "<redacted>" %>
             </td>
             <td style="width: 20%">
-              <button class="btn btn-primary btn-block show-create-modal" type="button" data-toggle="modal" data-target="#modifyPasswordModal">Modify</button>
+              <button class="btn btn_primary btn-block show-create-modal" type="button" data-toggle="modal" data-target="#modifyPasswordModal">Modify</button>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <div class="row" style="position: relative; top:30%">
-      <button type="button" class="btn btn-danger btn-block" data-toggle="modal" data-target="#destroyUserModal">
+      <button type="button" class="btn btn_danger btn-block" data-toggle="modal" data-target="#destroyUserModal">
         Destroy account
       </button>
     </div>

--- a/lib/rails_base/configuration/appearance.rb
+++ b/lib/rails_base/configuration/appearance.rb
@@ -5,18 +5,39 @@ require 'rails_base/configuration/display/background_color'
 require 'rails_base/configuration/display/navbar'
 require 'rails_base/configuration/display/text'
 require 'rails_base/configuration/display/footer'
+require 'rails_base/configuration/display/btn_primary'
+require 'rails_base/configuration/display/btn_secondary'
+require 'rails_base/configuration/display/btn_success'
+require 'rails_base/configuration/display/btn_danger'
+require 'rails_base/configuration/display/btn_warning'
+require 'rails_base/configuration/display/btn_info'
+require 'rails_base/configuration/display/btn_light'
+require 'rails_base/configuration/display/btn_dark'
 
 module RailsBase
   module Configuration
     class Appearance < Base
+      BUTTONS = [
+        :btn_primary,
+        :btn_secondary,
+        :btn_success,
+        :btn_danger,
+        :btn_warning,
+        :btn_info,
+        :btn_light,
+        :btn_dark,
+      ]
+
       DOWNSTREAM_CLASSES = [
         :t_header,
         :t_body,
         :bg_color,
         :navbar,
         :text,
-        :footer
-      ]
+        :footer,
+
+      ] + BUTTONS
+
       SKIP_DOWNSTREAM_CLASSES = [:footer]
       DARK_MODE = :dark
       LIGHT_MODE = :light
@@ -63,6 +84,15 @@ module RailsBase
         @navbar = Configuration::Display::Navbar.new
         @text = Configuration::Display::Text.new
         @footer = Configuration::Display::Footer.new
+
+        @btn_primary = Configuration::Display::BtnPrimary.new
+        @btn_secondary = Configuration::Display::BtnSecondary.new
+        @btn_success = Configuration::Display::BtnSuccess.new
+        @btn_danger = Configuration::Display::BtnDanger.new
+        @btn_warning = Configuration::Display::BtnWarning.new
+        @btn_info = Configuration::Display::BtnInfo.new
+        @btn_light = Configuration::Display::BtnLight.new
+        @btn_dark = Configuration::Display::BtnDark.new
 
         _validate_values
         super()

--- a/lib/rails_base/configuration/display/btn_danger.rb
+++ b/lib/rails_base/configuration/display/btn_danger.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnDanger < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-danger',
+            description: 'Button danger to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-danger',
+            description: 'Button danger to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_dark.rb
+++ b/lib/rails_base/configuration/display/btn_dark.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnDark < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-dark',
+            description: 'Button dark to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-dark',
+            description: 'Button dark to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_info.rb
+++ b/lib/rails_base/configuration/display/btn_info.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnInfo < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-info',
+            description: 'Button info to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-info',
+            description: 'Button info to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_light.rb
+++ b/lib/rails_base/configuration/display/btn_light.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnLight < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-light',
+            description: 'Button light to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-light',
+            description: 'Button light to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_primary.rb
+++ b/lib/rails_base/configuration/display/btn_primary.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnPrimary < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-primary',
+            description: 'Button primary to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-primary',
+            description: 'Button primary to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_secondary.rb
+++ b/lib/rails_base/configuration/display/btn_secondary.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnSecondary < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-light',
+            description: 'Button secondary to use in Dark mode. Please use btn_secondary as primary attribute instead of btn-secondary'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-secondary',
+            description: 'Button secondary to use in light mode.  Please use btn_secondary as primary attribute instead of btn-secondary'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_success.rb
+++ b/lib/rails_base/configuration/display/btn_success.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnSuccess < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-success',
+            description: 'Button success to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-success',
+            description: 'Button success to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/btn_warning.rb
+++ b/lib/rails_base/configuration/display/btn_warning.rb
@@ -1,0 +1,25 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class BtnWarning < Base
+
+        DEFAULT_VALUES = {
+          dark_mode: {
+            type: :string_nil,
+            default: 'btn-warning',
+            description: 'Button warning to use in Dark mode'
+          },
+          light_mode: {
+            type: :string_nil,
+            default: 'btn-warning',
+            description: 'Button warning to use in light mode'
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/configuration/display/footer.rb
+++ b/lib/rails_base/configuration/display/footer.rb
@@ -5,9 +5,12 @@ module RailsBase
     module Display
       class Footer < Base
         DEFAULT_PAGES = {
-          'RailsBase::Users::SessionsController' => [:new],
+          'RailsBase::Users::SessionsController' => [:new, :create],
+          'RailsBase::Users::PasswordsController' => [:new],
           'RailsBase::Users::RegistrationsController' => [:new],
           'RailsBase::UserSettingsController' => [:index],
+          'RailsBase::MfaAuthController' => [:mfa_code],
+          'RailsBase::SecondaryAuthenticationController' => [:static, :after_email_login_session_new, :forgot_password],
         }
         DEFAULT_FOOTER_HTML = "© 2021 Year of the Rona: Bad Ass Rails Starter <a href='https://github.com/matt-taylor/' target='_blank'>@matt-taylor</a>"
 
@@ -20,18 +23,26 @@ module RailsBase
           sticky: {
             type: :boolean,
             default: true,
+            dependents: [ -> (i) { i.enable? } ],
             description: 'Stick footer to the bottom of screen',
           },
           sticky_pages: {
             type: :hash,
             default: DEFAULT_PAGES,
+            popover: true,
+            decipher: ->(thing) { thing.map { |k, v| v.map { |a| "#{k}.#{a}"  } }.flatten },
             description: 'Pages that use sticky pages. All others wil append footer to end of body. NOTE: Action can be forced by calling `force_sticky_mode!` anytime.',
           },
           html: {
             type: :string,
             default: DEFAULT_FOOTER_HTML,
-            dependents: [ -> (i) { i.enable? } ],
             description: 'HTML text to be placed at footer'
+          },
+          content_bottom_or_sticky: {
+            type: :boolean,
+            default: true,
+            dependents: [ -> (i) { i.enable? } ],
+            description: 'When enabled, footer will stick to bottom or stick to bottom of content -- whichever is greater. Takes precendence over `sticky`',
           },
 
         }

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
-  MINOR = '42'
-  PATCH = '1'
+  MINOR = '43'
+  PATCH = '0'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
To use buttons in dark mode with the configuration, must replace bootstrap btn color name. Modify `-` to `_`
```
btn-primary => btn_primary,
btn-secondary => btn_secondary,
btn-success => btn_success,
btn-danger => btn_danger,
btn-warning => btn_warning,
btn-info => btn_info,
btn-light => btn_light,
btn-dark => btn_dark,
```