### PR TITLE
Use a captured path when fails to login

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_base (0.46.2)
+    rails_base (0.46.3)
       allow_numeric
       bootstrap
       browser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_base (0.46.3)
+    rails_base (0.47.0)
       allow_numeric
       bootstrap
       browser

--- a/app/controllers/rails_base/application_controller.rb
+++ b/app/controllers/rails_base/application_controller.rb
@@ -4,13 +4,16 @@ module RailsBase
     before_action :set_time_zone
     before_action :is_timeout_error?
     before_action :admin_reset_impersonation_session!
-    before_action :populate_admin_actions, if: -> { RailsBase.config.admin.enable_actions? }
     before_action :footer_mode_case
 
-    after_action :capture_admin_action, if: -> { RailsBase.config.admin.enable_actions? }
+    before_action :populate_admin_actions, if: -> { RailsBase.config.admin.enable_actions? }
+    after_action :capture_admin_action
+
+    # prepend_before_action :capture_reference
 
     include ApplicationHelper
     include AppearanceHelper
+    include CaptureReferenceHelper
 
     def set_time_zone
       return unless RailsBase.config.user.tz_user_defined?

--- a/app/controllers/rails_base/application_controller.rb
+++ b/app/controllers/rails_base/application_controller.rb
@@ -9,8 +9,6 @@ module RailsBase
     before_action :populate_admin_actions, if: -> { RailsBase.config.admin.enable_actions? }
     after_action :capture_admin_action
 
-    # prepend_before_action :capture_reference
-
     include ApplicationHelper
     include AppearanceHelper
     include CaptureReferenceHelper

--- a/app/controllers/rails_base/users/sessions_controller.rb
+++ b/app/controllers/rails_base/users/sessions_controller.rb
@@ -42,7 +42,10 @@ class RailsBase::Users::SessionsController < Devise::SessionsController
 
     sign_in(authenticate.user) if mfa_decision.sign_in_user
 
-    redirect_to mfa_decision.redirect_url, mfa_decision.flash
+    redirect = redirect_from_reference || mfa_decision.redirect_url
+    logger.info { "Successful sign in: Redirecting to #{redirect}" }
+
+    redirect_to(redirect, mfa_decision.flash)
   end
 
   # DELETE /user/sign_out

--- a/app/helpers/rails_base/capture_reference_helper.rb
+++ b/app/helpers/rails_base/capture_reference_helper.rb
@@ -1,0 +1,47 @@
+module RailsBase
+  module CaptureReferenceHelper
+    CAPTURE_CONTROLLER_PATH = :referer_controller_path
+    CAPTURE_ACTION_NAME = :referer_action_name
+    CAPTURE_REFERRED_PATH = :referer_referred_path
+
+    def authenticate_user!
+      # only if request is a get and not authenticated
+      capture_reference if request.method == 'GET' && !warden.authenticated?
+      super()
+    end
+
+    def capture_reference
+      return unless use_capture_reference?
+
+      session[CAPTURE_CONTROLLER_PATH] = controller_path
+      session[CAPTURE_ACTION_NAME] = action_name
+      session[CAPTURE_REFERRED_PATH] = request.path
+    end
+
+    def capture_clear_reference_from_sesssion!
+      session[CAPTURE_CONTROLLER_PATH] = nil
+      session[CAPTURE_ACTION_NAME] = nil
+      session[CAPTURE_REFERRED_PATH] = nil
+    end
+
+    def use_capture_reference?
+      RailsBase.config.login_behavior.fallback_to_referred
+    end
+
+    def reference_redirect
+      { controller: session[CAPTURE_CONTROLLER_PATH], action: session[CAPTURE_ACTION_NAME], path: session[CAPTURE_REFERRED_PATH] }
+    end
+
+    def capture_and_clear_reference_redirect!
+      temp = reference_redirect
+      capture_clear_reference_from_sesssion!
+      temp[:path]
+    end
+
+    def redirect_from_reference
+      return nil unless use_capture_reference?
+
+      capture_and_clear_reference_redirect!
+    end
+  end
+end

--- a/lib/rails_base/config.rb
+++ b/lib/rails_base/config.rb
@@ -8,10 +8,25 @@ require 'rails_base/configuration/exceptions_app'
 require 'rails_base/configuration/app_url'
 require 'rails_base/configuration/appearance'
 require 'rails_base/configuration/user'
+require 'rails_base/configuration/login_behavior'
 
 module RailsBase
   class Config
-    attr_reader :admin, :mfa, :auth, :redis, :owner, :mailer, :exceptions_app, :app_url, :appearance, :user
+    VARIABLES = [
+      :admin,
+      :mfa,
+      :auth,
+      :redis,
+      :owner,
+      :mailer,
+      :exceptions_app,
+      :app_url,
+      :appearance,
+      :user,
+      :login_behavior
+    ]
+    attr_reader *VARIABLES
+
     def initialize
       @admin = Configuration::Admin.new
       @mfa = Configuration::Mfa.new
@@ -23,32 +38,19 @@ module RailsBase
       @app_url = Configuration::AppUrl.new
       @appearance = Configuration::Appearance.new
       @user = Configuration::User.new
+      @login_behavior = Configuration::LoginBehavior.new
     end
 
     def validate_configs!
-      admin.validate!
-      mfa.validate!
-      auth.validate!
-      redis.validate!
-      owner.validate!
-      mailer.validate!
-      exceptions_app.validate!
-      app_url.validate!
-      appearance.validate!
-      user.validate!
+      VARIABLES.each do |var|
+        send(var).validate!
+      end
     end
 
     def reset_config!
-      admin.assign_default_values!
-      mfa.assign_default_values!
-      auth.assign_default_values!
-      redis.assign_default_values!
-      owner.assign_default_values!
-      mailer.assign_default_values!
-      exceptions_app.assign_default_values!
-      app_url.assign_default_values!
-      appearance.assign_default_values!
-      user.assign_default_values!
+      VARIABLES.each do |var|
+        send(var).assign_default_values!
+      end
     end
   end
 end

--- a/lib/rails_base/configuration/login_behavior.rb
+++ b/lib/rails_base/configuration/login_behavior.rb
@@ -1,0 +1,17 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    class LoginBehavior < Base
+
+      DEFAULT_VALUES = {
+        fallback_to_referred: {
+          type: :boolean,
+          default: true,
+          description: 'Enable capturing requests context when login fails. Upon login, redirect user to page they tried to go to.',
+        }
+      }
+      attr_accessor *DEFAULT_VALUES.keys
+    end
+  end
+end

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
-  MINOR = '46'
-  PATCH = '3'
+  MINOR = '47'
+  PATCH = '0'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
   MINOR = '46'
-  PATCH = '2'
+  PATCH = '3'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
When a user fails to login because they are not authenticated, store the path they tried to go to in the session

- Only if it is a get request
- only if they are not authenticated

Notes:
- This will cause issues with json requests
- Need to find a work around this

Can turn this off via config settings or by overloading 
```ruby
def use_capture_reference?
```
in the downstream controller class. For example, downstream controllers can choose to always return `false` if they do not want to use the captured paths