### PR TITLE
Customize max use count for email verification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_base (0.55.0)
+    rails_base (0.56.0)
       allow_numeric
       bootstrap (~> 4.6.0)
       browser

--- a/app/services/rails_base/authentication/send_verification_email.rb
+++ b/app/services/rails_base/authentication/send_verification_email.rb
@@ -8,15 +8,22 @@ module RailsBase::Authentication
 		delegate :user, to: :context
 		delegate :reason, to: :context
 
-		MAX_USE_COUNT = 1.freeze
 		DATA_USE = :alphanumeric
 		VELOCITY_MAX = 5
 		VELOCITY_MAX_IN_FRAME = 10.minutes
 		VELOCITY_FRAME = 1.hour
 
 		REASON_MAPPER = {
-			Constants::SVE_LOGIN_REASON => { method: :email_verification, url_method: :email_verification_url },
-			Constants::SVE_FORGOT_REASON => { method: :forgot_password, url_method: :forgot_password_auth_url }
+			Constants::SVE_LOGIN_REASON => {
+				method: :email_verification,
+				url_method: :email_verification_url,
+				max_use: RailsBase.config.login_behavior.email_max_use_verification
+			},
+			Constants::SVE_FORGOT_REASON => {
+				method: :forgot_password,
+				url_method: :forgot_password_auth_url,
+				max_use: RailsBase.config.login_behavior.email_max_use_forgot
+			}
 		}
 
 		def call
@@ -61,7 +68,7 @@ module RailsBase::Authentication
 		def create_short_lived_data
 			params = {
 				user: user,
-				max_use: MAX_USE_COUNT,
+				max_use: REASON_MAPPER[reason][:max_use],
 				reason: reason,
 				data_use: DATA_USE,
 				ttl: Constants::SVE_TTL,

--- a/lib/rails_base/configuration/login_behavior.rb
+++ b/lib/rails_base/configuration/login_behavior.rb
@@ -9,7 +9,17 @@ module RailsBase
           type: :boolean,
           default: true,
           description: 'Enable capturing requests context when login fails. Upon login, redirect user to page they tried to go to.',
-        }
+        },
+        email_max_use_verification:{
+          type: :integer,
+          default: 2,
+          description: 'Maximum number of times User can click link for verifiaction',
+        },
+        email_max_use_forgot:{
+          type: :integer,
+          default: 2,
+          description: 'Maximum number of times User can click link for forgot password flow',
+        },
       }
       attr_accessor *DEFAULT_VALUES.keys
     end

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,6 +1,6 @@
 module RailsBase
   MAJOR = '0'
-  MINOR = '55'
+  MINOR = '56'
   PATCH = '0'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 

--- a/spec/app/services/authentication/send_verification_email_spec.rb
+++ b/spec/app/services/authentication/send_verification_email_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe RailsBase::Authentication::SendVerificationEmail do
 			expect(ShortLivedData).to receive(:create_data_key).with(
 				hash_including(
 					user: user,
-					max_use: described_class::MAX_USE_COUNT,
+					max_use: described_class::REASON_MAPPER[reason][:max_use],
 					reason: reason,
 					data_use: described_class::DATA_USE,
 					ttl: RailsBase::Authentication::Constants::SVE_TTL,


### PR DESCRIPTION
email verification and forgot email flow -- max use was 1; we saw that occasionally with other browser, the content would get loaded first. This means that the useage was already used. 

---

This probably needs to get cleaned up and remove all usage count once password has been reset