### PR TITLE
Modify View for Reset password

### DIFF
--- a/app/views/rails_base/shared/_password_confirm_javascript.html.erb
+++ b/app/views/rails_base/shared/_password_confirm_javascript.html.erb
@@ -29,8 +29,6 @@
         unknown_chars.push(special_chars_array[i])
       }
     }
-    console.log(`Unkown Charaters: ${unknown_chars}`)
-    console.log(`special_chars_array: ${special_chars_array}`)
     if(unknown_chars.length > 0) {
       return false
     }

--- a/app/views/rails_base/shared/_reset_password_form.html.erb
+++ b/app/views/rails_base/shared/_reset_password_form.html.erb
@@ -59,8 +59,21 @@
       return false
     }
 
-    var unknown = value.replace(/[0-9a-zA-Z]/g,'')
-    if(unknown.length > 0) {
+    var special_chars = value.replace(/[0-9a-zA-Z]/g,'')
+
+    if (special_chars.length == 0) {
+      return true
+    }
+    password_allowed_special_chars = <%= raw (RailsBase.config.auth.password_allowed_special_chars || "").split("") %>
+
+    special_chars_array = special_chars.split("")
+    unknown_chars = []
+    for (let i = 0; i < special_chars_array.length; i++) {
+      if(!password_allowed_special_chars.includes(special_chars_array[i])){
+        unknown_chars.push(special_chars_array[i])
+      }
+    }
+    if(unknown_chars.length > 0) {
       return false
     }
     true

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
   MINOR = '73'
-  PATCH = '0'
+  PATCH = '1'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
## What

The client side validation format was not working for resetting password flow for special characters. The client side JS is duplicated in two separate view templates. It eventually needs to be unified but is fine for now

## Changes
- Update version
- copy JS for special characters to reset password flow