### PR TITLE
Add header partial config

### DIFF
--- a/app/views/layouts/rails_base/application.html.erb
+++ b/app/views/layouts/rails_base/application.html.erb
@@ -110,6 +110,12 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
+        <% if partial = RailsBase.config.appearance.header.partial %>
+          <%= render partial: partial %>
+        <% end %>
+      <div >
+
+      </div>
       <div class="p-1">
         <%= yield %>
       </div>

--- a/app/views/rails_base/shared/_admin_actions_modal.html.erb
+++ b/app/views/rails_base/shared/_admin_actions_modal.html.erb
@@ -9,7 +9,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <h5> Admins have made actions recently on your account. Aknowledge to clear alert. </h5>
+        <h5> Admins have made actions recently on your account. Acknowledge to clear alert. </h5>
         </br>
         <% @__admin_actions_array.reverse.each do |action, time| %>
           <div class="alert alert-danger alert-dismissible fade show" role="alert">

--- a/lib/rails_base/configuration/appearance.rb
+++ b/lib/rails_base/configuration/appearance.rb
@@ -10,6 +10,7 @@ require 'rails_base/configuration/display/btn_secondary'
 require 'rails_base/configuration/display/btn_success'
 require 'rails_base/configuration/display/btn_warning'
 require 'rails_base/configuration/display/footer'
+require 'rails_base/configuration/display/header'
 require 'rails_base/configuration/display/navbar'
 require 'rails_base/configuration/display/table_body'
 require 'rails_base/configuration/display/table_header'
@@ -42,10 +43,11 @@ module RailsBase
         :text,
         :card,
         :footer,
+        :header,
         :back_to_top,
       ] + BUTTONS
 
-      SKIP_DOWNSTREAM_CLASSES = [:footer, :back_to_top]
+      SKIP_DOWNSTREAM_CLASSES = [:footer, :header, :back_to_top]
       DARK_MODE = :dark
       LIGHT_MODE = :light
       MATCH_OS = :match_os
@@ -92,6 +94,7 @@ module RailsBase
         @text = Configuration::Display::Text.new
         @card = Configuration::Display::Card.new
         @footer = Configuration::Display::Footer.new
+        @header = Configuration::Display::Header.new
         @back_to_top = Configuration::Display::BackTotop.new
         @bg_light = Configuration::Display::BgLight.new
 

--- a/lib/rails_base/configuration/display/footer.rb
+++ b/lib/rails_base/configuration/display/footer.rb
@@ -44,7 +44,6 @@ module RailsBase
             dependents: [ -> (i) { i.enable? } ],
             description: 'When enabled, footer will stick to bottom or stick to bottom of content -- whichever is greater. Takes precendence over `sticky`',
           },
-
         }
 
         attr_accessor *DEFAULT_VALUES.keys

--- a/lib/rails_base/configuration/display/header.rb
+++ b/lib/rails_base/configuration/display/header.rb
@@ -1,0 +1,20 @@
+require 'rails_base/configuration/base'
+
+module RailsBase
+  module Configuration
+    module Display
+      class Header < Base
+
+        DEFAULT_VALUES = {
+          partial: {
+            type: :string_nil,
+            default: nil,
+            description: "Rails partial to render at the header."
+          },
+        }
+
+        attr_accessor *DEFAULT_VALUES.keys
+      end
+    end
+  end
+end

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
-  MINOR = '73'
-  PATCH = '1'
+  MINOR = '74'
+  PATCH = '0'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
## Changes
- Add config for header partial
- Allows customized html to be rendered before body of page and after 
- This can be used to customize adding a bootstrap modal or alert to every single page