### PR TITLE
Upgrade Ruby Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.75.1
+- Allow Ruby version to be customizable
+- This way, the Gemfile can use the default ruby that CI setups and Heroku can evaluate which version to use
+
 ## v0.75.0
 - Rails 6.1 or greater enforced
 - Zeitwerk 2.6.5 or greater enforced

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+# Use custom ruby version or whatever is already defined
+ruby ENV["CUSTOM_RUBY_VERSION"] || RUBY_VERSION
+
 gem 'rails', ENV.fetch("BUNDLER_RAILS_VERSION", '~> 6')
 
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_base (0.75.0)
+    rails_base (0.75.1)
       allow_numeric
       bootstrap (~> 4.6.0)
       browser
@@ -367,6 +367,9 @@ DEPENDENCIES
   timecop
   web-console
   webrick
+
+RUBY VERSION
+   ruby 3.0.1p64
 
 BUNDLED WITH
    2.5.3

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
   MINOR = '75'
-  PATCH = '0'
+  PATCH = '1'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
# Problem:
The Gemfile.lock does not specify which ruby version to use. This causes Heroku to get confused and use the default 2.6.6.
This is bad because 2.6.6 is no longer supported

# Solution:
Allow the ruby version to be dynamically assigned to allow for CI testing but also allow for heroku deployment

This has no impact on downstream repos