### PR TITLE
[Fix] Allow reload to specify a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ module Dummy
 
     # Allow all files under `app/models` to be re-opened by the Dummy Application
     RailsBase.reloadable_paths!(relative_path: "app/models")
+    # Or to just reload the user model
+    RailsBase.reloadable_paths!(only_files: ["app/models/user.rb"])
     ...
   end
 end

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
   MINOR = '75'
-  PATCH = '4'
+  PATCH = '5'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
# Problem:
Before we were forced to include an entire directory. This forced all files in the directory to be reloaded and ignored via autoloader. 

This is a nusiance for downstream serviecs that have constants. We would receive warnings about constants getting reloaded like: 
```ruby
# /home/app/app/models/users.rb:33: warning: previous definition of MY_USER_CONSTANT was here
```

# Solution:
Allow downstream user to just input the files they want to add to the reloader block
