### PR TITLE
[Feature] Add toggle/close/hide functionality for Standartdized Collapse

### DIFF
--- a/app/views/rails_base/shared/_standardized_collapse.html.erb
+++ b/app/views/rails_base/shared/_standardized_collapse.html.erb
@@ -54,8 +54,8 @@
     _rails_base_toggle_base_footer('hide')
     $(`#<%= body %>`).collapse('show')
     <% if use_fa_icon %>
-      $(`#<%= fa_icon_span_id %> .open`).show()
-      $(`#<%= fa_icon_span_id %> .closed`).hide()
+      $(`#<%= fa_icon_span_id %> .open`).hide()
+      $(`#<%= fa_icon_span_id %> .closed`).show()
     <% end %>
   }
 
@@ -63,7 +63,7 @@
     _rails_base_toggle_base_footer('hide')
     $(`#<%= body %>`).collapse('hide')
     <% if use_fa_icon %>
-      $(`#<%= fa_icon_span_id %> .open`).hide()
+      $(`#<%= fa_icon_span_id %> .open`).show()
       $(`#<%= fa_icon_span_id %> .closed`).hide()
     <% end %>
   }

--- a/app/views/rails_base/shared/_standardized_collapse.html.erb
+++ b/app/views/rails_base/shared/_standardized_collapse.html.erb
@@ -15,6 +15,7 @@
   close_display = start_open ? 'inline' : 'none'
   open_display = !start_open ? 'inline' : 'none'
   id_transposed = "id_transposed_#{rand(100_000..999_999)}"
+  function_name = options.fetch(:function_name, id_transposed)
 %>
 
 <% if use_fa_icon %>
@@ -48,6 +49,33 @@
       $(`#<%= fa_icon_span_id %> .closed`).toggle()
     <% end %>
   });
+
+  function <%= function_name %>_collapse_open(){
+    _rails_base_toggle_base_footer('hide')
+    $(`#<%= body %>`).collapse('show')
+    <% if use_fa_icon %>
+      $(`#<%= fa_icon_span_id %> .open`).show()
+      $(`#<%= fa_icon_span_id %> .closed`).hide()
+    <% end %>
+  }
+
+  function <%= function_name %>_collapse_close(){
+    _rails_base_toggle_base_footer('hide')
+    $(`#<%= body %>`).collapse('hide')
+    <% if use_fa_icon %>
+      $(`#<%= fa_icon_span_id %> .open`).hide()
+      $(`#<%= fa_icon_span_id %> .closed`).hide()
+    <% end %>
+  }
+
+  function <%= function_name %>_collapse_toggle(){
+    _rails_base_toggle_base_footer('hide')
+    $(`#<%= body %>`).collapse('toggle')
+    <% if use_fa_icon %>
+      $(`#<%= fa_icon_span_id %> .open`).toggle()
+      $(`#<%= fa_icon_span_id %> .closed`).toggle()
+    <% end %>
+  }
 
   $(`#<%= body %>`).on('shown.bs.collapse', function () {
     _rails_base_reload_base_footer();

--- a/lib/rails_base/configuration/appearance.rb
+++ b/lib/rails_base/configuration/appearance.rb
@@ -140,5 +140,3 @@ module RailsBase
     end
   end
 end
-
-

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = '0'
   MINOR = '75'
-  PATCH = '5'
+  PATCH = '6'
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version


### PR DESCRIPTION
## Problem

The standardized collapse functionality when rendered downstream has no way to easily progromatically toggle the fucntionality of closing and opening

## Solution:
Pass in funciont_name to allow downstream to set the function name for toggle opena nd close for the standardized collapse