### PR TITLE
[Feature] Allow custom phone number for SSO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_base (0.81.1)
+    rails_base (0.82.0)
       allow_numeric
       bootstrap (~> 4.6.0)
       browser

--- a/app/services/rails_base/authentication/single_sign_on_send.rb
+++ b/app/services/rails_base/authentication/single_sign_on_send.rb
@@ -58,7 +58,7 @@ module RailsBase::Authentication
     # This method is expected to be overridden by the main app
     # This is expected default behavior if SSO is available
     def sso_decision_type
-      if user.phone_number.present?
+      if phone.present?
         SSO_DECISION_TWILIO
       elsif user.email_validated
         SSO_DECISION_EMAIL
@@ -69,13 +69,17 @@ module RailsBase::Authentication
     end
 
     def send_to_twilio!(message:)
-      TwilioJob.perform_later(message: message, to: user.phone_number)
-      log(level: :info, msg: "Sent twilio message to #{user.phone_number}")
+      TwilioJob.perform_later(message: message, to: phone)
+      log(level: :info, msg: "Sent twilio message to #{phone}")
     rescue StandardError => e
       log(level: :error, msg: "Error caught #{e.class.name}")
       log(level: :error, msg: "Error caught #{e.message}")
-      log(level: :error, msg: "Failed to send sms to #{user.phone_number}")
+      log(level: :error, msg: "Failed to send sms to #{phone}")
       context.fail!(message: "Failed to send sms to user. Try again.")
+    end
+
+    def phone
+      context.phone_number || user.phone_number
     end
 
     def send_to_email!(message:)

--- a/lib/rails_base/version.rb
+++ b/lib/rails_base/version.rb
@@ -1,7 +1,7 @@
 module RailsBase
   MAJOR = "0"
-  MINOR = "81"
-  PATCH = "1"
+  MINOR = "82"
+  PATCH = "0"
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
   def self.print_version

--- a/spec/app/services/authentication/single_sign_on_send_spec.rb
+++ b/spec/app/services/authentication/single_sign_on_send_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RailsBase::Authentication::SingleSignOnSend do
   subject(:call) { described_class.call(params) }
 
   let(:instance) { described_class.new(params) }
-  let(:user) { User.first }
+  let(:user) { create(:user) }
   let(:token_length) { 32 }
   let(:token_type) { :alphanumeric }
   let(:uses) { nil }
@@ -54,10 +54,23 @@ RSpec.describe RailsBase::Authentication::SingleSignOnSend do
         end
       end
 
+      context "with custom phone" do
+        let(:phone_number) { "4158675309" }
+        let(:params) { super().merge(phone_number: phone_number) }
+        it 'sends to twilio' do
+          expect(TwilioHelper).to receive(:send_sms).with(
+            message: /Hello #{user.full_name}. This is your SSO link/,
+            to: phone_number,
+          )
+
+          call
+        end
+      end
+
       it 'sends to twilio' do
         expect(TwilioHelper).to receive(:send_sms).with(
           message: /Hello #{user.full_name}. This is your SSO link/,
-          to: user.phone_number
+          to: user.phone_number,
         )
 
         call

--- a/spec/app/services/authentication/single_sign_on_send_spec.rb
+++ b/spec/app/services/authentication/single_sign_on_send_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe RailsBase::Authentication::SingleSignOnSend do
   end
 
   describe '#call' do
+    before { allow(TwilioHelper).to receive(:send_sms) }
     context 'when sso_decision_type is invalid' do
       before do
         allow(user).to receive(:phone_number).and_return(nil)


### PR DESCRIPTION
For SSO Send, you may not always have a phone number attached to the user. Or maybe you have multiple